### PR TITLE
remove GA

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -25,16 +25,5 @@
   <link href="/assets/css/foundation.css" rel="stylesheet" type="text/css" />
   <link href="/assets/fonts/foundation-icons/foundation-icons.css" rel="stylesheet" type="text/css" />
   <!--[if lt IE 9]><script src="/assets/js/libs/html5shiv.js" type="text/javascript"></script><![endif]-->
-  {% if site.ga %}
-  <script type="text/javascript">
-            var _gaq = _gaq || [];
-            _gaq.push(['_setAccount', '{{ site.ga }}']);
-            _gaq.push(['_trackPageview']);
-            (function() {
-                var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-                ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-                var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-            })();
-  </script>
-  {% endif %}
+
 </head>


### PR DESCRIPTION
Usnesení CF zakazuje používat Google Analytics na pirátských webech.